### PR TITLE
Add rent_now_or_reserve and rent_now_or_reserve_fee CTAs

### DIFF
--- a/lib/g5_integrations_validations/site_link_inventory_validations.rb
+++ b/lib/g5_integrations_validations/site_link_inventory_validations.rb
@@ -4,7 +4,16 @@ module G5IntegrationsValidations::SiteLinkInventoryValidations
   VALID_IN_STORE_RATE_BASES = VALID_RATE_BASES + ['calculated_from_web_rate']
   VALID_WEB_RATE_BASES = VALID_RATE_BASES + ['calculated_from_in_store_rate']
   CTAS_FOR_IN_AND_ABOVE_THRESHOLD = %w(quote reserve)
-  CTAS_FOR_IN_AND_ABOVE_THRESHOLD_WITH_RENT_NOW = ['quote', 'reserve', 'reserve_fee', 'rent_now']
+  CTAS_FOR_IN_AND_ABOVE_THRESHOLD_WITH_RENT_NOW = [
+    'quote',
+    'reserve',
+    'reserve_fee',
+    # todo: before removing 'rent_now', make sure this doesn't
+    # isn't used by any app using this gem
+    'rent_now',
+    'rent_now_or_reserve',
+    'rent_now_or_reserve_fee'
+  ]
   CTAS_FOR_BELOW_THRESHOLD = %w(call quote)
 
   extend ActiveSupport::Concern

--- a/spec/g5_integrations_validations/site_link_inventory_validations_spec.rb
+++ b/spec/g5_integrations_validations/site_link_inventory_validations_spec.rb
@@ -11,7 +11,7 @@ describe G5IntegrationsValidations::SiteLinkInventoryValidations do
   it do
     is_expected.
       to validate_inclusion_of(:unit_availability_cta_in_and_above_threshold).
-      in_array(['quote', 'reserve', 'rent_now'])
+      in_array(['quote', 'reserve', 'rent_now', 'rent_now_or_reserve', 'rent_now_or_reserve_fee'])
   end
   it do
     is_expected.


### PR DESCRIPTION
- 'rent_now' should be removed after ensuring all gems have migrated to 'rent_now_or_reserve' CTA
  [#91773456]

http://pivotaltracker.com/story/show/91773456
